### PR TITLE
Fix typo in pscheck.sh

### DIFF
--- a/pscheck.sh
+++ b/pscheck.sh
@@ -18,7 +18,7 @@ process_name() {
       ;;
     *)
       if [ -f /proc/$1/comm ]; then
-        cat /proc/$P/comm
+        cat /proc/$1/comm
       fi
       ;;
   esac


### PR DESCRIPTION
I want to use this script on linux as well and I noticed this typo.